### PR TITLE
Fix division by zero in ChaosToExalted

### DIFF
--- a/components/utils.js
+++ b/components/utils.js
@@ -11,6 +11,7 @@ async function Delay(DelaySize = 2) {
 }
 
 function ChaosToExalted(ExaltedValue = 0, ChaosValue = 0) {
+  if (ExaltedValue === 0) return 0;
   return parseFloat(parseFloat(ChaosValue / ExaltedValue).toFixed(1));
 }
 


### PR DESCRIPTION
## Summary
- safeguard ChaosToExalted for when ExaltedValue is zero

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848ac47ee8c8333925188f03d6dcd4a