### PR TITLE
Add delay option to queue

### DIFF
--- a/src/infra/async-queue/simple-async-queue.ts
+++ b/src/infra/async-queue/simple-async-queue.ts
@@ -1,11 +1,24 @@
 import { IAsyncQueue } from '../../application/ports/async-queue.interface';
+import sleep from '../../shared/helpers/sleep.helper';
 
 export default class SimpleAsyncQueue<T> implements IAsyncQueue<T> {
   private lastPromise: Promise<unknown> = Promise.resolve();
 
+  constructor(private readonly delayInMs = 0) {}
+
   async insertAndProcess<R>(job: (input?: T) => Promise<R>): Promise<R> {
-    const result = this.lastPromise.then(() => job());
+    const result = this.lastPromise
+      .then(() => job())
+      .then(async (jobResult) => {
+        if (this.delayInMs > 0) {
+          await sleep(this.delayInMs);
+        }
+
+        return jobResult;
+      });
+
     this.lastPromise = result.catch(() => {});
+
     return result;
   }
 }


### PR DESCRIPTION
## Summary
- extend `SimpleAsyncQueue` with an optional delay parameter
- delay the result resolution for each queued task
- keep `HttpClient` behavior unchanged

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c00aae808333aec57d779b2e13c7