### PR TITLE
Add PoeNinja HTTP service with retry

### DIFF
--- a/src/infra/http/poe-ninja/index.ts
+++ b/src/infra/http/poe-ninja/index.ts
@@ -1,0 +1,4 @@
+import PoeNinjaService from './poe-ninja.service';
+
+export default PoeNinjaService;
+export * from './poe-ninja.service';

--- a/src/infra/http/poe-ninja/poe-ninja.service.ts
+++ b/src/infra/http/poe-ninja/poe-ninja.service.ts
@@ -1,0 +1,65 @@
+import { IHttpClient } from '../../../application/ports/http-client.interface';
+import ValidateHttpResponseUseCase from '../../../application/use-cases/validate-http-response.use-case';
+import sleep from '../../../shared/helpers/sleep.helper';
+import InfraException from '../../exceptions/infra.exception';
+
+export type PoeNinjaQueryParams = {
+  language?: string;
+  league: string;
+  type: string;
+};
+
+export default class PoeNinjaService {
+  private readonly httpClient: IHttpClient;
+
+  private readonly baseURL: string;
+
+  constructor(httpClient: IHttpClient, baseURL = 'https://poe.ninja/api/data') {
+    this.httpClient = httpClient;
+    this.baseURL = baseURL.replace(/\/$/, '');
+  }
+
+  private buildURL(endpoint: string, params: PoeNinjaQueryParams): string {
+    const searchParams = new URLSearchParams({
+      language: params.language ?? 'en',
+      league: params.league,
+      type: params.type,
+    });
+
+    return `${this.baseURL}/${endpoint}?${searchParams.toString()}`;
+  }
+
+  private async requestWithRetry<T>(
+    url: string,
+    retries = 3,
+    delay = 1000,
+  ): Promise<T> {
+    try {
+      const response = await this.httpClient.get<T>({ url });
+      new ValidateHttpResponseUseCase({ request: { url }, response }).execute();
+
+      if (!response.data) {
+        throw new InfraException(PoeNinjaService.name, 'No data returned');
+      }
+
+      return response.data;
+    } catch (e) {
+      if (retries <= 1) {
+        throw e;
+      }
+
+      await sleep(delay);
+      return this.requestWithRetry(url, retries - 1, delay * 2);
+    }
+  }
+
+  async fetchItemOverview<T>(params: PoeNinjaQueryParams): Promise<T> {
+    const url = this.buildURL('itemoverview', params);
+    return this.requestWithRetry<T>(url);
+  }
+
+  async fetchCurrencyOverview<T>(params: PoeNinjaQueryParams): Promise<T> {
+    const url = this.buildURL('currencyoverview', params);
+    return this.requestWithRetry<T>(url);
+  }
+}

--- a/src/infra/http/poe-ninja/tests/poe-ninja.service.spec.ts
+++ b/src/infra/http/poe-ninja/tests/poe-ninja.service.spec.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
+import StatusCode from 'status-code-enum';
+
+import PoeNinjaService from '..';
+
+import type {
+  IHttpClient,
+  HttpClientGetProps,
+  HttpClientResponse,
+} from '../../../../application/ports/http-client.interface';
+
+jest.useFakeTimers();
+
+describe(PoeNinjaService.name, () => {
+  it('should retry the request on failure', async () => {
+    const responses: Array<
+      HttpClientResponse<{ lines: Array<{ ok: boolean }> }>
+    > = [
+      { data: null, headers: {}, statusCode: StatusCode.ServerErrorInternal },
+      {
+        data: { lines: [{ ok: true }] },
+        headers: {},
+        statusCode: StatusCode.SuccessOK,
+      },
+    ];
+
+    const getMock = jest
+      .fn<
+        Promise<HttpClientResponse<{ lines: Array<{ ok: boolean }> }>>,
+        [HttpClientGetProps]
+      >()
+      .mockImplementation(() =>
+        Promise.resolve(responses.shift()!),
+      ) as unknown as IHttpClient['get'];
+
+    const fakeHttpClient: IHttpClient = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      get: getMock,
+    };
+
+    const service = new PoeNinjaService(fakeHttpClient, 'http://localhost');
+
+    const promise = service.fetchItemOverview({ league: 'Test', type: 'Map' });
+    await Promise.all([promise, jest.runAllTimersAsync()]);
+    const result = await promise;
+
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ lines: [{ ok: true }] });
+  });
+});


### PR DESCRIPTION
## Summary
- provide HTTP service for poe.ninja endpoints
- support retry with exponential backoff
- test retry logic using a mocked HttpClient

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848bff4d75c833397a5127774e7ea58