### PR TITLE
Add async queue test

### DIFF
--- a/src/infra/async-queue/__tests__/simple-async-queue.spec.ts
+++ b/src/infra/async-queue/__tests__/simple-async-queue.spec.ts
@@ -1,0 +1,33 @@
+import SimpleAsyncQueue from '../simple-async-queue';
+
+describe('SimpleAsyncQueue', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const createDelayedJob = <T>(value: T, delay: number, markers: number[], start: number) =>
+    new Promise<T>((resolve) => {
+      markers.push(Date.now() - start);
+      setTimeout(() => resolve(value), delay);
+    });
+
+  it('should resolve queued promises in order and respect delays', async () => {
+    const queue = new SimpleAsyncQueue<void>();
+    const startTime = Date.now();
+    const startMarkers: number[] = [];
+
+    const first = queue.insertAndProcess(() => createDelayedJob('first', 50, startMarkers, startTime));
+    const second = queue.insertAndProcess(() => createDelayedJob('second', 30, startMarkers, startTime));
+    const third = queue.insertAndProcess(() => createDelayedJob('third', 20, startMarkers, startTime));
+
+    await jest.runAllTimersAsync();
+    const results = await Promise.all([first, second, third]);
+
+    expect(results).toEqual(['first', 'second', 'third']);
+    expect(startMarkers).toEqual([0, 50, 80]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for SimpleAsyncQueue verifying order and delay handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848bfe09ee083339c1ce8bec5099ad5