### PR TITLE
Refactor queue delay initialization

### DIFF
--- a/src/infra/async-queue/simple-async-queue.ts
+++ b/src/infra/async-queue/simple-async-queue.ts
@@ -4,10 +4,11 @@ import sleep from '../../shared/helpers/sleep.helper';
 export default class SimpleAsyncQueue<T> implements IAsyncQueue<T> {
   private readonly delayInMs: number;
 
-  private lastPromise: Promise<unknown> = Promise.resolve();
+  private lastPromise: Promise<unknown>;
 
   constructor(delayInMs = 0) {
     this.delayInMs = delayInMs;
+    this.lastPromise = Promise.resolve();
   }
 
   async insertAndProcess<R>(job: (input?: T) => Promise<R>): Promise<R> {


### PR DESCRIPTION
## Summary
- initialize `delayInMs` and `lastPromise` inside the `SimpleAsyncQueue` constructor

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684972bd01b48333b800ae4fdea2fb5d