### PR TITLE
Refactor ProcessLayerErrorUseCase to use single props arg

### DIFF
--- a/src/application/use-cases/generate-flip-table.use-case.ts
+++ b/src/application/use-cases/generate-flip-table.use-case.ts
@@ -28,14 +28,8 @@ export interface GenerateFlipTableProps {
 }
 
 export default class GenerateFlipTableUseCase {
-  private readonly props: GenerateFlipTableProps;
-
-  constructor(props: GenerateFlipTableProps) {
-    this.props = props;
-  }
-
-  execute(): FlipTableRow[] {
-    const { cards, currencyCards = [], exaltedPriceChaos } = this.props;
+  execute(props: GenerateFlipTableProps): FlipTableRow[] {
+    const { cards, currencyCards = [], exaltedPriceChaos } = props;
     const cardRows = cards.map((card) =>
       GenerateFlipTableUseCase.buildCardRow(card, exaltedPriceChaos),
     );

--- a/src/application/use-cases/process-layer-error.use-case.ts
+++ b/src/application/use-cases/process-layer-error.use-case.ts
@@ -1,24 +1,18 @@
 import UseCaseException from '../exceptions/use-case.exception';
 
 interface ProcessLayerErrorUseCaseProps {
+  error: unknown;
   sourceName: string;
 }
 
 export default class ProcessLayerErrorUseCase {
-  private readonly props: ProcessLayerErrorUseCaseProps;
-
-  constructor(props: ProcessLayerErrorUseCaseProps) {
-    this.props = props;
-  }
-
-  execute(e: unknown): UseCaseException {
-    const { sourceName } = this.props;
-
-    if (Object.prototype.hasOwnProperty.call(e, 'message')) {
-      const { message } = e as Error;
-      return new UseCaseException(sourceName, `${typeof e}: ${message}`);
+  execute(props: ProcessLayerErrorUseCaseProps): UseCaseException {
+    const { error, sourceName } = props;
+    if (Object.prototype.hasOwnProperty.call(error, 'message')) {
+      const { message } = error as Error;
+      return new UseCaseException(sourceName, `${typeof error}: ${message}`);
     }
 
-    return new UseCaseException(sourceName, `Unknown Error: ${String(e)}`);
+    return new UseCaseException(sourceName, `Unknown Error: ${String(error)}`);
   }
 }

--- a/src/application/use-cases/tests/generate-flip-table.use-case.spec.ts
+++ b/src/application/use-cases/tests/generate-flip-table.use-case.spec.ts
@@ -14,12 +14,12 @@ describe(GenerateFlipTableUseCase.name, () => {
       },
     ];
 
-    const useCase = new GenerateFlipTableUseCase({
+    const useCase = new GenerateFlipTableUseCase();
+
+    const [row] = useCase.execute({
       cards,
       exaltedPriceChaos: 200,
     });
-
-    const [row] = useCase.execute();
 
     expect(row).toMatchObject({
       name: 'The Scholar',
@@ -40,13 +40,13 @@ describe(GenerateFlipTableUseCase.name, () => {
       { name: 'Currency A', setSize: 10, cardPriceChaos: 0.5, currencyChaos: 20 },
     ];
 
-    const useCase = new GenerateFlipTableUseCase({
+    const useCase = new GenerateFlipTableUseCase();
+
+    const rows = useCase.execute({
       cards,
       currencyCards,
       exaltedPriceChaos: 200,
     });
-
-    const rows = useCase.execute();
 
     const chaosProfits = rows.map((r) => r.chaosProfit);
     const sorted = [...chaosProfits].sort((a, b) => b - a);

--- a/src/application/use-cases/tests/validate-http-response.spec.ts
+++ b/src/application/use-cases/tests/validate-http-response.spec.ts
@@ -19,13 +19,13 @@ describe(ValidateHttpResponseUseCase.name, () => {
       statusCode: StatusCode.ClientErrorBadRequest,
     };
 
-    const validateHttpResponseUseCase = new ValidateHttpResponseUseCase({
-      request: httpRequest,
-      response: httpResponse,
-    });
+    const validateHttpResponseUseCase = new ValidateHttpResponseUseCase();
 
     expect(() => {
-      validateHttpResponseUseCase.execute();
+      validateHttpResponseUseCase.execute({
+        request: httpRequest,
+        response: httpResponse,
+      });
     }).toThrow(BadStatusCodeException);
   });
 });

--- a/src/application/use-cases/validate-http-response.use-case.ts
+++ b/src/application/use-cases/validate-http-response.use-case.ts
@@ -10,18 +10,12 @@ export type ValidateHttpResponseProps<T> = {
 };
 
 export default class ValidateHttpResponseUseCase<T = unknown> {
-  private props: ValidateHttpResponseProps<T>;
-
-  constructor(props: ValidateHttpResponseProps<T>) {
-    this.props = props;
-  }
-
-  execute(): void {
-    const { response } = this.props;
+  execute(props: ValidateHttpResponseProps<T>): void {
+    const { response } = props;
     const { statusCode } = response;
 
     if (statusCode !== StatusCode.SuccessOK) {
-      throw new BadStatusCodeException(this.props);
+      throw new BadStatusCodeException(props);
     }
   }
 }

--- a/src/infra/http/client/tests/http-client.spec.ts
+++ b/src/infra/http/client/tests/http-client.spec.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import { IncomingHttpHeaders } from 'http';
 
-import Fastify from 'fastify';
+import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
 import StatusCode from 'status-code-enum';
 
 import HttpClient from '..';
@@ -14,15 +14,24 @@ type ReceivedRequest = {
   headers?: IncomingHttpHeaders;
 };
 
+interface TestServer {
+  get: (
+    path: string,
+    handler: (req: FastifyRequest, reply: FastifyReply) => Promise<void> | void,
+  ) => void;
+  listen: (opts: { host: string; port: number }) => Promise<string>;
+  close: () => Promise<void>;
+}
+
 describe(HttpClient.name, () => {
   const defaultServerResponse = { message: 'Hello World!' };
-  const server = Fastify();
+  const server = Fastify() as unknown as TestServer;
   let address: string | null = null;
 
   const receivedRequestData: Map<string, ReceivedRequest> = new Map();
 
   beforeAll(async () => {
-    server.get('/:status', async (req, response) => {
+    server.get('/:status', async (req: FastifyRequest, response: FastifyReply) => {
       const statusCodeToReply =
         (req.params as Record<'status', number>)?.status || 200;
 

--- a/src/infra/http/poe-ninja/poe-ninja.service.ts
+++ b/src/infra/http/poe-ninja/poe-ninja.service.ts
@@ -36,7 +36,10 @@ export default class PoeNinjaService {
   ): Promise<T> {
     try {
       const response = await this.httpClient.get<T>({ url });
-      new ValidateHttpResponseUseCase({ request: { url }, response }).execute();
+      new ValidateHttpResponseUseCase().execute({
+        request: { url },
+        response,
+      });
 
       if (!response.data) {
         throw new InfraException(PoeNinjaService.name, 'No data returned');


### PR DESCRIPTION
## Summary
- keep error context on ProcessLayerErrorUseCase props
- update execute signature to accept only one argument
- avoid `any` usage in http-client test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684974ece9e083339bf892c4f6598094