### PR TITLE
Refactor overview mappers to inject builders

### DIFF
--- a/src/application/ports/mapper.interface.ts
+++ b/src/application/ports/mapper.interface.ts
@@ -5,3 +5,7 @@ interface IMapper<T extends EntityNames> {
 }
 
 export interface IHttpLeagueMapper extends IMapper<'LeagueEntity'> {}
+export interface IHttpItemOverviewMapper
+  extends IMapper<'ItemOverviewEntity'> {}
+export interface IHttpCurrencyOverviewMapper
+  extends IMapper<'CurrencyOverviewEntity'> {}

--- a/src/application/types/build-entity.type.ts
+++ b/src/application/types/build-entity.type.ts
@@ -1,12 +1,23 @@
 import LeagueEntity, {
   LeagueEntityProps,
 } from '../../domain/entities/league.entity';
+import ItemOverviewEntity, {
+  PoeNinjaItemOverviewLine,
+} from '../../domain/entities/item-overview.entity';
+import CurrencyOverviewEntity, {
+  PoeNinjaCurrencyOverviewLine,
+} from '../../domain/entities/currency-overview.entity';
 
 export type EntityMap = {
-  [K in typeof LeagueEntity.name]: LeagueEntity;
+  LeagueEntity: LeagueEntity;
+  ItemOverviewEntity: ItemOverviewEntity;
+  CurrencyOverviewEntity: CurrencyOverviewEntity;
 };
+
 export type EntityPropsMap = {
-  [K in typeof LeagueEntity.name]: LeagueEntityProps;
+  LeagueEntity: LeagueEntityProps;
+  ItemOverviewEntity: PoeNinjaItemOverviewLine;
+  CurrencyOverviewEntity: PoeNinjaCurrencyOverviewLine;
 };
 
 export type EntityNames = keyof EntityMap;

--- a/src/infra/http/league/league.mapper.ts
+++ b/src/infra/http/league/league.mapper.ts
@@ -3,14 +3,10 @@ import BuildEntityUseCase from '../../../application/use-cases/build-entity.use-
 
 import { HttpLeagueResponse } from './types/http-league-response.type';
 
-const entityTargetName = 'LeagueEntity';
-
 export default class HttpLeagueMapper implements IHttpLeagueMapper {
-  private readonly entityBuilder: BuildEntityUseCase<typeof entityTargetName>;
-
-  constructor() {
-    this.entityBuilder = new BuildEntityUseCase(entityTargetName);
-  }
+  constructor(
+    private readonly entityBuilder: BuildEntityUseCase<'LeagueEntity'>,
+  ) {}
 
   toDomain(league: HttpLeagueResponse) {
     return this.entityBuilder.execute(league);

--- a/src/infra/http/poe-ninja/currency-overview.mapper.ts
+++ b/src/infra/http/poe-ninja/currency-overview.mapper.ts
@@ -1,0 +1,13 @@
+import { IHttpCurrencyOverviewMapper } from '../../../application/ports/mapper.interface';
+import BuildEntityUseCase from '../../../application/use-cases/build-entity.use-case';
+import { PoeNinjaCurrencyOverviewLine } from '../../../domain/entities/currency-overview.entity';
+
+export default class HttpCurrencyOverviewMapper implements IHttpCurrencyOverviewMapper {
+  constructor(
+    private readonly entityBuilder: BuildEntityUseCase<'CurrencyOverviewEntity'>,
+  ) {}
+
+  toDomain(line: PoeNinjaCurrencyOverviewLine) {
+    return this.entityBuilder.execute(line);
+  }
+}

--- a/src/infra/http/poe-ninja/index.ts
+++ b/src/infra/http/poe-ninja/index.ts
@@ -1,4 +1,7 @@
 import PoeNinjaService from './poe-ninja.service';
+import HttpItemOverviewMapper from './item-overview.mapper';
+import HttpCurrencyOverviewMapper from './currency-overview.mapper';
 
 export default PoeNinjaService;
 export * from './poe-ninja.service';
+export { HttpItemOverviewMapper, HttpCurrencyOverviewMapper };

--- a/src/infra/http/poe-ninja/item-overview.mapper.ts
+++ b/src/infra/http/poe-ninja/item-overview.mapper.ts
@@ -1,0 +1,13 @@
+import { IHttpItemOverviewMapper } from '../../../application/ports/mapper.interface';
+import BuildEntityUseCase from '../../../application/use-cases/build-entity.use-case';
+import { PoeNinjaItemOverviewLine } from '../../../domain/entities/item-overview.entity';
+
+export default class HttpItemOverviewMapper implements IHttpItemOverviewMapper {
+  constructor(
+    private readonly entityBuilder: BuildEntityUseCase<'ItemOverviewEntity'>,
+  ) {}
+
+  toDomain(line: PoeNinjaItemOverviewLine) {
+    return this.entityBuilder.execute(line);
+  }
+}


### PR DESCRIPTION
## Summary
- refactor league, item overview and currency overview mappers to receive `BuildEntityUseCase` instances via constructor
- remove default dependency instantiation from constructors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849d70973c88333bb1d65817fabd0a7