### PR TITLE
Enable absolute imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  moduleNameMapper: {
+    '^application/(.*)$': '<rootDir>/src/application/$1',
+    '^domain/(.*)$': '<rootDir>/src/domain/$1',
+    '^infra/(.*)$': '<rootDir>/src/infra/$1',
+    '^shared/(.*)$': '<rootDir>/src/shared/$1',
+  },
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },

--- a/src/application/exceptions/http.exception.ts
+++ b/src/application/exceptions/http.exception.ts
@@ -1,5 +1,5 @@
-import { HttpClientResponse } from '../ports/http-client.interface';
-import { HttpRequest } from '../types/http-request.type';
+import { HttpClientResponse } from 'application/ports/http-client.interface';
+import { HttpRequest } from 'application/types/http-request.type';
 
 export type HttpExceptionProps<T = unknown> = Pick<Error, 'message'> & {
   request: HttpRequest;

--- a/src/application/ports/http-repository.interface.ts
+++ b/src/application/ports/http-repository.interface.ts
@@ -1,4 +1,4 @@
-import { EntityMap, EntityNames } from '../types/build-entity.type';
+import { EntityMap, EntityNames } from 'application/types/build-entity.type';
 
 interface IHttpRepository<T extends EntityNames> {
   fetchAll(): Promise<Array<EntityMap[T]>>;

--- a/src/application/ports/mapper.interface.ts
+++ b/src/application/ports/mapper.interface.ts
@@ -1,4 +1,4 @@
-import { EntityNames, EntityMap } from '../types/build-entity.type';
+import { EntityNames, EntityMap } from 'application/types/build-entity.type';
 
 interface IMapper<T extends EntityNames> {
   toDomain(data: unknown): EntityMap[T];

--- a/src/application/types/build-entity.type.ts
+++ b/src/application/types/build-entity.type.ts
@@ -1,12 +1,12 @@
 import LeagueEntity, {
   LeagueEntityProps,
-} from '../../domain/entities/league.entity';
+} from 'domain/entities/league.entity';
 import ItemOverviewEntity, {
   PoeNinjaItemOverviewLine,
-} from '../../domain/entities/item-overview.entity';
+} from 'domain/entities/item-overview.entity';
 import CurrencyOverviewEntity, {
   PoeNinjaCurrencyOverviewLine,
-} from '../../domain/entities/currency-overview.entity';
+} from 'domain/entities/currency-overview.entity';
 
 export type EntityMap = {
   LeagueEntity: LeagueEntity;

--- a/src/application/types/http-request.type.ts
+++ b/src/application/types/http-request.type.ts
@@ -1,3 +1,3 @@
-import { HttpClientGetProps } from '../ports/http-client.interface';
+import { HttpClientGetProps } from 'application/ports/http-client.interface';
 
 export type HttpRequest = Pick<HttpClientGetProps, 'url' | 'headers'>;

--- a/src/application/types/http-response.type.ts
+++ b/src/application/types/http-response.type.ts
@@ -1,3 +1,3 @@
-import { HttpClientResponse } from '../ports/http-client.interface';
+import { HttpClientResponse } from 'application/ports/http-client.interface';
 
 export type HttpResponse<T = unknown> = HttpClientResponse<T>;

--- a/src/application/use-cases/build-entity.use-case.ts
+++ b/src/application/use-cases/build-entity.use-case.ts
@@ -1,15 +1,15 @@
 import CurrencyOverviewEntity, {
   PoeNinjaCurrencyOverviewLine,
-} from '../../domain/entities/currency-overview.entity';
+} from 'domain/entities/currency-overview.entity';
 import ItemOverviewEntity, {
   PoeNinjaItemOverviewLine,
-} from '../../domain/entities/item-overview.entity';
-import LeagueEntity, { LeagueEntityProps } from '../../domain/entities/league.entity';
+} from 'domain/entities/item-overview.entity';
+import LeagueEntity, { LeagueEntityProps } from 'domain/entities/league.entity';
 import {
   EntityMap,
   EntityNames,
   EntityPropsMap,
-} from '../types/build-entity.type';
+} from 'application/types/build-entity.type';
 
 type BuilderFn<K extends EntityNames> = (
   props: EntityPropsMap[K],

--- a/src/application/use-cases/find-leagues.use-case.ts
+++ b/src/application/use-cases/find-leagues.use-case.ts
@@ -1,5 +1,5 @@
-import LeagueEntity from '../../domain/entities/league.entity';
-import { ILeagueRepository } from '../ports/http-repository.interface';
+import LeagueEntity from 'domain/entities/league.entity';
+import { ILeagueRepository } from 'application/ports/http-repository.interface';
 
 export interface FindLeaguesUseCaseInterfaces {
   readonly leagueRepository: ILeagueRepository;

--- a/src/application/use-cases/process-layer-error.use-case.ts
+++ b/src/application/use-cases/process-layer-error.use-case.ts
@@ -1,4 +1,4 @@
-import UseCaseException from '../exceptions/use-case.exception';
+import UseCaseException from 'application/exceptions/use-case.exception';
 
 interface ProcessLayerErrorUseCaseProps {
   error: unknown;

--- a/src/application/use-cases/tests/generate-flip-table.use-case.spec.ts
+++ b/src/application/use-cases/tests/generate-flip-table.use-case.spec.ts
@@ -1,7 +1,7 @@
 import GenerateFlipTableUseCase, {
   CardRowInput,
   CurrencyCardRowInput,
-} from '../generate-flip-table.use-case';
+} from 'application/use-cases/generate-flip-table.use-case';
 
 describe(GenerateFlipTableUseCase.name, () => {
   it('should compute profits for card rows', () => {

--- a/src/application/use-cases/tests/validate-http-response.spec.ts
+++ b/src/application/use-cases/tests/validate-http-response.spec.ts
@@ -1,9 +1,9 @@
 import { StatusCode } from 'status-code-enum';
 
-import BadStatusCodeException from '../../exceptions/bad-status-code.exception';
-import { HttpRequest } from '../../types/http-request.type';
-import { HttpResponse } from '../../types/http-response.type';
-import ValidateHttpResponseUseCase from '../validate-http-response.use-case';
+import BadStatusCodeException from 'application/exceptions/bad-status-code.exception';
+import { HttpRequest } from 'application/types/http-request.type';
+import { HttpResponse } from 'application/types/http-response.type';
+import ValidateHttpResponseUseCase from 'application/use-cases/validate-http-response.use-case';
 
 describe(ValidateHttpResponseUseCase.name, () => {
   const httpRequest: HttpRequest = {

--- a/src/application/use-cases/validate-http-response.use-case.ts
+++ b/src/application/use-cases/validate-http-response.use-case.ts
@@ -1,8 +1,8 @@
 import { StatusCode } from 'status-code-enum';
 
-import BadStatusCodeException from '../exceptions/bad-status-code.exception';
-import { HttpRequest } from '../types/http-request.type';
-import { HttpResponse } from '../types/http-response.type';
+import BadStatusCodeException from 'application/exceptions/bad-status-code.exception';
+import { HttpRequest } from 'application/types/http-request.type';
+import { HttpResponse } from 'application/types/http-response.type';
 
 export type ValidateHttpResponseProps<T> = {
   request: HttpRequest;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
-import FindLeaguesUseCase from './application/use-cases/find-leagues.use-case';
-import HttpClient from './infra/http/client';
-import HttpLeagueRepository from './infra/http/league/league.repository';
+import FindLeaguesUseCase from 'application/use-cases/find-leagues.use-case';
+import HttpClient from 'infra/http/client';
+import HttpLeagueRepository from 'infra/http/league/league.repository';
 
 import type {
   APIGatewayEvent,

--- a/src/infra/async-queue/__tests__/simple-async-queue.spec.ts
+++ b/src/infra/async-queue/__tests__/simple-async-queue.spec.ts
@@ -1,4 +1,4 @@
-import SimpleAsyncQueue from '../simple-async-queue';
+import SimpleAsyncQueue from 'infra/async-queue/simple-async-queue';
 
 describe('SimpleAsyncQueue', () => {
   beforeEach(() => {

--- a/src/infra/async-queue/simple-async-queue.ts
+++ b/src/infra/async-queue/simple-async-queue.ts
@@ -1,5 +1,5 @@
-import { IAsyncQueue } from '../../application/ports/async-queue.interface';
-import sleep from '../../shared/helpers/sleep.helper';
+import { IAsyncQueue } from 'application/ports/async-queue.interface';
+import sleep from 'shared/helpers/sleep.helper';
 
 export default class SimpleAsyncQueue<T> implements IAsyncQueue<T> {
   private readonly delayInMs: number;

--- a/src/infra/http/client/axios-http-client.ts
+++ b/src/infra/http/client/axios-http-client.ts
@@ -8,13 +8,13 @@ import Axios, {
   CreateAxiosDefaults,
 } from 'axios';
 
-import HttpException from '../../../application/exceptions/http.exception';
+import HttpException from 'application/exceptions/http.exception';
 import {
   IHttpClient,
   HttpClientGetProps,
   HttpClientResponse,
-} from '../../../application/ports/http-client.interface';
-import InfraException from '../../exceptions/infra.exception';
+} from 'application/ports/http-client.interface';
+import InfraException from 'infra/exceptions/infra.exception';
 
 import { DEFAULT_USER_AGENT, DEFAULT_REQUEST_TIMEOUT } from './constants';
 

--- a/src/infra/http/client/index.ts
+++ b/src/infra/http/client/index.ts
@@ -1,10 +1,10 @@
-import { IAsyncQueue } from '../../../application/ports/async-queue.interface';
+import { IAsyncQueue } from 'application/ports/async-queue.interface';
 import {
   IHttpClient,
   HttpClientGetProps,
   HttpClientResponse,
-} from '../../../application/ports/http-client.interface';
-import SimpleAsyncQueue from '../../async-queue/simple-async-queue';
+} from 'application/ports/http-client.interface';
+import SimpleAsyncQueue from 'infra/async-queue/simple-async-queue';
 
 import AxiosHttpClient from './axios-http-client';
 

--- a/src/infra/http/client/tests/http-client.spec.ts
+++ b/src/infra/http/client/tests/http-client.spec.ts
@@ -3,9 +3,9 @@ import { randomUUID } from 'crypto';
 import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
 import StatusCode from 'status-code-enum';
 
-import HttpClient from '..';
-import HttpException from '../../../../application/exceptions/http.exception';
-import { DEFAULT_USER_AGENT } from '../constants';
+import HttpClient from 'infra/http/client';
+import HttpException from 'application/exceptions/http.exception';
+import { DEFAULT_USER_AGENT } from 'infra/http/client/constants';
 
 import type { IncomingHttpHeaders } from 'http';
 

--- a/src/infra/http/league/league.mapper.ts
+++ b/src/infra/http/league/league.mapper.ts
@@ -1,5 +1,5 @@
-import { IHttpLeagueMapper } from '../../../application/ports/mapper.interface';
-import BuildEntityUseCase from '../../../application/use-cases/build-entity.use-case';
+import { IHttpLeagueMapper } from 'application/ports/mapper.interface';
+import BuildEntityUseCase from 'application/use-cases/build-entity.use-case';
 
 import { HttpLeagueResponse } from './types/http-league-response.type';
 

--- a/src/infra/http/league/league.repository.ts
+++ b/src/infra/http/league/league.repository.ts
@@ -1,7 +1,7 @@
-import { IHttpClient } from '../../../application/ports/http-client.interface';
-import { ILeagueRepository } from '../../../application/ports/http-repository.interface';
-import { IHttpLeagueMapper } from '../../../application/ports/mapper.interface';
-import InfraException from '../../exceptions/infra.exception';
+import { IHttpClient } from 'application/ports/http-client.interface';
+import { ILeagueRepository } from 'application/ports/http-repository.interface';
+import { IHttpLeagueMapper } from 'application/ports/mapper.interface';
+import InfraException from 'infra/exceptions/infra.exception';
 
 import HttpLeagueMapper from './league.mapper';
 import { HttpLeagueResponse } from './types/http-league-response.type';

--- a/src/infra/http/poe-ninja/currency-overview.mapper.ts
+++ b/src/infra/http/poe-ninja/currency-overview.mapper.ts
@@ -1,6 +1,6 @@
-import { IHttpCurrencyOverviewMapper } from '../../../application/ports/mapper.interface';
-import BuildEntityUseCase from '../../../application/use-cases/build-entity.use-case';
-import { PoeNinjaCurrencyOverviewLine } from '../../../domain/entities/currency-overview.entity';
+import { IHttpCurrencyOverviewMapper } from 'application/ports/mapper.interface';
+import BuildEntityUseCase from 'application/use-cases/build-entity.use-case';
+import { PoeNinjaCurrencyOverviewLine } from 'domain/entities/currency-overview.entity';
 
 export default class HttpCurrencyOverviewMapper implements IHttpCurrencyOverviewMapper {
   constructor(

--- a/src/infra/http/poe-ninja/item-overview.mapper.ts
+++ b/src/infra/http/poe-ninja/item-overview.mapper.ts
@@ -1,6 +1,6 @@
-import { IHttpItemOverviewMapper } from '../../../application/ports/mapper.interface';
-import BuildEntityUseCase from '../../../application/use-cases/build-entity.use-case';
-import { PoeNinjaItemOverviewLine } from '../../../domain/entities/item-overview.entity';
+import { IHttpItemOverviewMapper } from 'application/ports/mapper.interface';
+import BuildEntityUseCase from 'application/use-cases/build-entity.use-case';
+import { PoeNinjaItemOverviewLine } from 'domain/entities/item-overview.entity';
 
 export default class HttpItemOverviewMapper implements IHttpItemOverviewMapper {
   constructor(

--- a/src/infra/http/poe-ninja/poe-ninja.service.ts
+++ b/src/infra/http/poe-ninja/poe-ninja.service.ts
@@ -1,7 +1,7 @@
-import { IHttpClient } from '../../../application/ports/http-client.interface';
-import ValidateHttpResponseUseCase from '../../../application/use-cases/validate-http-response.use-case';
-import sleep from '../../../shared/helpers/sleep.helper';
-import InfraException from '../../exceptions/infra.exception';
+import { IHttpClient } from 'application/ports/http-client.interface';
+import ValidateHttpResponseUseCase from 'application/use-cases/validate-http-response.use-case';
+import sleep from 'shared/helpers/sleep.helper';
+import InfraException from 'infra/exceptions/infra.exception';
 
 export type PoeNinjaQueryParams = {
   language?: string;

--- a/src/infra/http/poe-ninja/tests/poe-ninja.service.spec.ts
+++ b/src/infra/http/poe-ninja/tests/poe-ninja.service.spec.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
 import StatusCode from 'status-code-enum';
 
-import PoeNinjaService from '..';
+import PoeNinjaService from 'infra/http/poe-ninja';
 
 import type {
   IHttpClient,
   HttpClientGetProps,
   HttpClientResponse,
-} from '../../../../application/ports/http-client.interface';
+} from 'application/ports/http-client.interface';
 
 jest.useFakeTimers();
 

--- a/src/shared/helpers/tests/sleep.spec.ts
+++ b/src/shared/helpers/tests/sleep.spec.ts
@@ -1,4 +1,4 @@
-import sleep from '../sleep.helper';
+import sleep from 'shared/helpers/sleep.helper';
 
 jest.useFakeTimers();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "isolatedModules": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "baseUrl": "./src",
     "noImplicitAny": true,
     "outDir": "dist",
     "preserveConstEnums": true,


### PR DESCRIPTION
## Summary
- configure TypeScript and Jest for absolute imports
- update source and test files to use absolute paths instead of relative traversals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b3bd859088333bac89c0490db74e9