### PR TITLE
Improve FetchFlipDataUseCase

### DIFF
--- a/src/application/use-cases/fetch-flip-data.use-case.ts
+++ b/src/application/use-cases/fetch-flip-data.use-case.ts
@@ -1,0 +1,75 @@
+import { ItemOverviewType } from 'config/fetch-list';
+import CurrencyOverviewEntity from 'domain/entities/currency-overview.entity';
+import ItemOverviewEntity from 'domain/entities/item-overview.entity';
+import {
+  ICurrencyOverviewRepository,
+  IItemOverviewRepository,
+} from 'application/ports/http-repository.interface';
+
+export interface FetchFlipDataUseCaseInterfaces {
+  readonly itemRepository: IItemOverviewRepository;
+  readonly currencyRepository: ICurrencyOverviewRepository;
+}
+
+export interface FetchFlipDataUseCaseConfig {
+  readonly itemTypes: ItemOverviewType[];
+  readonly currencyType?: string;
+}
+
+export interface FetchFlipDataUseCaseConstructor {
+  readonly interfaces: FetchFlipDataUseCaseInterfaces;
+  readonly config: FetchFlipDataUseCaseConfig;
+}
+
+export interface LeagueFlipData {
+  readonly items: ItemOverviewEntity[];
+  readonly currencies: CurrencyOverviewEntity[];
+}
+
+const DEFAULT_CURRENCY_TYPE = 'Currency' as const;
+
+export default class FetchFlipDataUseCase {
+  private readonly interfaces: FetchFlipDataUseCaseInterfaces;
+
+  private readonly config: FetchFlipDataUseCaseConfig;
+
+  constructor({ interfaces, config }: FetchFlipDataUseCaseConstructor) {
+    this.interfaces = interfaces;
+    this.config = config;
+  }
+
+  async execute(leagues: string[]): Promise<Record<string, LeagueFlipData>> {
+    const { currencyRepository } = this.interfaces;
+    const { currencyType = DEFAULT_CURRENCY_TYPE } = this.config;
+
+    const result: Record<string, LeagueFlipData> = {};
+
+    for (const league of leagues) {
+      const items = await this.fetchItemsByLeague(league);
+      const currencies = await currencyRepository.fetchAll({
+        league,
+        type: currencyType,
+      });
+
+      result[league] = { items, currencies };
+    }
+
+    return result;
+  }
+
+  private async fetchItemsByLeague(
+    league: string,
+  ): Promise<ItemOverviewEntity[]> {
+    const { itemRepository } = this.interfaces;
+    const { itemTypes } = this.config;
+
+    const items: ItemOverviewEntity[] = [];
+
+    for (const type of itemTypes) {
+      const fetched = await itemRepository.fetchAll({ league, type });
+      items.push(...fetched);
+    }
+
+    return items;
+  }
+}

--- a/src/application/use-cases/tests/fetch-flip-data.use-case.spec.ts
+++ b/src/application/use-cases/tests/fetch-flip-data.use-case.spec.ts
@@ -1,0 +1,81 @@
+import FetchFlipDataUseCase from 'application/use-cases/fetch-flip-data.use-case';
+import { ItemOverviewType } from 'config/fetch-list';
+import CurrencyOverviewEntity from 'domain/entities/currency-overview.entity';
+import ItemOverviewEntity from 'domain/entities/item-overview.entity';
+import {
+  ICurrencyOverviewRepository,
+  IItemOverviewRepository,
+} from 'application/ports/http-repository.interface';
+
+const league = 'Sanctum';
+const itemTypes: ItemOverviewType[] = ['DivinationCard'];
+
+describe(FetchFlipDataUseCase.name, () => {
+  it('aggregates data for each league', async () => {
+    const itemEntities = [
+      new ItemOverviewEntity({
+        chaosValue: 1,
+        detailsId: 'a',
+        name: 'ItemA',
+      }),
+    ];
+    const currencyEntities = [
+      new CurrencyOverviewEntity({
+        chaosEquivalent: 1,
+        currencyTypeName: 'Chaos Orb',
+        detailsId: 'chaos-orb',
+      }),
+    ];
+
+    const itemRepository: IItemOverviewRepository = {
+      fetchAll: jest.fn().mockResolvedValue(itemEntities),
+    };
+    const currencyRepository: ICurrencyOverviewRepository = {
+      fetchAll: jest.fn().mockResolvedValue(currencyEntities),
+    };
+
+    const useCase = new FetchFlipDataUseCase({
+      interfaces: { itemRepository, currencyRepository },
+      config: { itemTypes },
+    });
+
+    const result = await useCase.execute([league]);
+
+    expect(result[league].items).toEqual(itemEntities);
+    expect(result[league].currencies).toEqual(currencyEntities);
+    expect(itemRepository.fetchAll).toHaveBeenCalledWith({ league, type: 'DivinationCard' });
+    expect(currencyRepository.fetchAll).toHaveBeenCalledWith({ league, type: 'Currency' });
+  });
+
+  it('throws when item repository fails', async () => {
+    const itemRepository: IItemOverviewRepository = {
+      fetchAll: jest.fn().mockRejectedValue(new Error('fail')),
+    };
+    const currencyRepository: ICurrencyOverviewRepository = {
+      fetchAll: jest.fn(),
+    };
+
+    const useCase = new FetchFlipDataUseCase({
+      interfaces: { itemRepository, currencyRepository },
+      config: { itemTypes },
+    });
+
+    await expect(useCase.execute([league])).rejects.toThrow('fail');
+  });
+
+  it('throws when currency repository fails', async () => {
+    const itemRepository: IItemOverviewRepository = {
+      fetchAll: jest.fn().mockResolvedValue([]),
+    };
+    const currencyRepository: ICurrencyOverviewRepository = {
+      fetchAll: jest.fn().mockRejectedValue(new Error('fail')),
+    };
+
+    const useCase = new FetchFlipDataUseCase({
+      interfaces: { itemRepository, currencyRepository },
+      config: { itemTypes },
+    });
+
+    await expect(useCase.execute([league])).rejects.toThrow('fail');
+  });
+});


### PR DESCRIPTION
## Summary
- refactor fetch-flip-data use case to avoid nested loops
- add unit test for currency repository failure

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684b428f51788333998556641f8626b6