### PR TITLE
Add flip table repository interface and console impl

### DIFF
--- a/src/application/ports/flip-table-repository.interface.ts
+++ b/src/application/ports/flip-table-repository.interface.ts
@@ -1,0 +1,5 @@
+import { FlipTableRow } from 'application/use-cases/generate-flip-table.use-case';
+
+export interface IFlipTableRepository {
+  save(table: FlipTableRow[], league: string): Promise<void>;
+}

--- a/src/infra/console-flip-table.repository.ts
+++ b/src/infra/console-flip-table.repository.ts
@@ -1,0 +1,16 @@
+/* eslint-disable no-console */
+import { IFlipTableRepository } from 'application/ports/flip-table-repository.interface';
+import { FlipTableRow } from 'application/use-cases/generate-flip-table.use-case';
+
+export default class ConsoleFlipTableRepository implements IFlipTableRepository {
+  private readonly tables: Record<string, FlipTableRow[]> = {};
+
+  async save(table: FlipTableRow[], league: string): Promise<void> {
+    this.tables[league] = table;
+    console.log({ league, table });
+  }
+
+  get data(): Record<string, FlipTableRow[]> {
+    return this.tables;
+  }
+}


### PR DESCRIPTION
## Summary
- define `IFlipTableRepository` interface for persisting flip tables
- implement `ConsoleFlipTableRepository` that stores tables in memory and logs them

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b486b92f48333a8aad03f01a8ebec