### PR TITLE
Implement flip table workflow

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '^domain/(.*)$': '<rootDir>/src/domain/$1',
     '^infra/(.*)$': '<rootDir>/src/infra/$1',
     '^shared/(.*)$': '<rootDir>/src/shared/$1',
+    '^config/(.*)$': '<rootDir>/src/config/$1',
   },
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,79 @@
+import ConsoleFlipTableRepository from 'infra/console-flip-table.repository';
+import HttpLeagueRepository from 'infra/http/league/league.repository';
+import HttpItemOverviewRepository from 'infra/http/poe-ninja/item-overview.repository';
+import HttpCurrencyOverviewRepository from 'infra/http/poe-ninja/currency-overview.repository';
+import LeagueEntity from 'domain/entities/league.entity';
+import ItemOverviewEntity from 'domain/entities/item-overview.entity';
+import CurrencyOverviewEntity from 'domain/entities/currency-overview.entity';
+import { ItemClass } from 'domain/entities/item-class.enum';
+import { main } from './index';
+
+const saveMock = jest.fn();
+const fetchLeaguesMock = jest.fn();
+const fetchItemsMock = jest.fn();
+const fetchCurrenciesMock = jest.fn();
+
+jest.mock('infra/console-flip-table.repository', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ save: saveMock })),
+}), { virtual: true });
+jest.mock('infra/http/league/league.repository', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ fetchAll: fetchLeaguesMock })),
+}), { virtual: true });
+jest.mock('infra/http/poe-ninja/item-overview.repository', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ fetchAll: fetchItemsMock })),
+}), { virtual: true });
+jest.mock('infra/http/poe-ninja/currency-overview.repository', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ fetchAll: fetchCurrenciesMock })),
+}), { virtual: true });
+
+describe('main flow', () => {
+  it('fetches data and saves flip tables for leagues', async () => {
+    const league = new LeagueEntity({
+      delveEvent: false,
+      endAt: null,
+      id: 'Test',
+      realm: 'pc',
+      rules: [],
+      startAt: null,
+      url: '',
+    });
+    fetchLeaguesMock.mockResolvedValue([league]);
+
+    const items = [
+      new ItemOverviewEntity({
+        chaosValue: 2,
+        detailsId: 'card',
+        itemClass: ItemClass.DivinationCard,
+        name: "The Wolven King's Bite",
+        stackSize: 5,
+      }),
+      new ItemOverviewEntity({
+        chaosValue: 10,
+        detailsId: 'reward',
+        itemClass: ItemClass.Unique,
+        name: "Rigwald's Quills",
+      }),
+    ];
+    fetchItemsMock.mockResolvedValue(items);
+
+    const currencies = [
+      new CurrencyOverviewEntity({
+        chaosEquivalent: 200,
+        currencyTypeName: 'Exalted Orb',
+        detailsId: 'exalted-orb',
+      }),
+    ];
+    fetchCurrenciesMock.mockResolvedValue(currencies);
+
+    await main();
+
+    expect(fetchLeaguesMock).toHaveBeenCalledTimes(1);
+    expect(fetchItemsMock).toHaveBeenCalledWith({ league: 'Test', type: 'DivinationCard' });
+    expect(fetchCurrenciesMock).toHaveBeenCalledWith({ league: 'Test', type: 'Currency' });
+    expect(saveMock).toHaveBeenCalledWith(expect.any(Array), 'Test');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,18 @@
 /* eslint-disable no-console */
 
 import FindLeaguesUseCase from 'application/use-cases/find-leagues.use-case';
+import FetchFlipDataUseCase from 'application/use-cases/fetch-flip-data.use-case';
+import GenerateFlipTableUseCase from 'application/use-cases/generate-flip-table.use-case';
+import FETCH_LIST from 'config/fetch-list';
+import CARDS from 'config/cards';
+import CURRENCY_CARDS from 'config/currency-cards';
+import { ItemClass } from 'domain/entities/item-class.enum';
 import HttpClient from 'infra/http/client';
 import HttpLeagueRepository from 'infra/http/league/league.repository';
+import PoeNinjaService from 'infra/http/poe-ninja';
+import HttpItemOverviewRepository from 'infra/http/poe-ninja/item-overview.repository';
+import HttpCurrencyOverviewRepository from 'infra/http/poe-ninja/currency-overview.repository';
+import ConsoleFlipTableRepository from 'infra/console-flip-table.repository';
 
 import type {
   APIGatewayEvent,
@@ -15,14 +25,72 @@ async function main() {
   const httpClient = new HttpClient();
 
   const leagueRepository = new HttpLeagueRepository(httpClient);
+  const poeNinjaService = new PoeNinjaService(httpClient);
+
+  const itemRepository = new HttpItemOverviewRepository(poeNinjaService);
+  const currencyRepository = new HttpCurrencyOverviewRepository(poeNinjaService);
+  const flipTableRepository = new ConsoleFlipTableRepository();
+
   const findLeaguesUseCase = new FindLeaguesUseCase({
     interfaces: {
       leagueRepository,
     },
   });
 
+  const fetchFlipDataUseCase = new FetchFlipDataUseCase({
+    interfaces: { itemRepository, currencyRepository },
+    config: { itemTypes: FETCH_LIST },
+  });
+
   const leagueEntities = await findLeaguesUseCase.execute();
-  console.log(leagueEntities);
+  const leagues = leagueEntities.map((l) => l.name);
+
+  const leagueData = await fetchFlipDataUseCase.execute(leagues);
+
+  for (const league of leagues) {
+    const { items, currencies } = leagueData[league];
+
+    const exaltedPriceChaos =
+      currencies.find((c) => c.name === 'Exalted Orb')?.chaosValue ?? 0;
+
+    const cardRows = CARDS.map((card) => {
+      const cardItem = items.find(
+        (i) => i.name === card.cardName && i.itemClass === ItemClass.DivinationCard,
+      );
+      const rewardItem = items.find(
+        (i) => i.name === card.rewardName && i.itemClass === card.itemClass,
+      );
+
+      return {
+        cardPriceChaos: cardItem?.chaosValue ?? 0,
+        name: card.cardName,
+        rewardChaos: rewardItem?.chaosValue ?? 0,
+        setSize: cardItem?.stackSize ?? 0,
+      };
+    });
+
+    const currencyCardRows = CURRENCY_CARDS.map((card) => {
+      const cardItem = items.find(
+        (i) => i.name === card.cardName && i.itemClass === ItemClass.DivinationCard,
+      );
+      const currencyItem = currencies.find((c) => c.name === card.rewardName);
+
+      return {
+        cardPriceChaos: cardItem?.chaosValue ?? 0,
+        currencyChaos: (currencyItem?.chaosValue ?? 0) * card.amount,
+        name: card.cardName,
+        setSize: card.amount,
+      };
+    });
+
+    const flipTable = GenerateFlipTableUseCase.execute({
+      cards: cardRows,
+      currencyCards: currencyCardRows,
+      exaltedPriceChaos,
+    });
+
+    await flipTableRepository.save(flipTable, league);
+  }
 }
 
 const handler = async (
@@ -57,4 +125,4 @@ if (process.env.NODE_ENV === 'development') {
   process.nextTick(async () => main());
 }
 
-export { handler };
+export { handler, main };


### PR DESCRIPTION
## Summary
- wire index to fetch flip data and save flip tables
- add module alias for config in Jest
- test the main workflow with mocked infra

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b49ff8804833395165e6e9fde500d