### PR TITLE
Fix divination reward parser

### DIFF
--- a/src/application/use-cases/fetch-divination-card-rewards.use-case.ts
+++ b/src/application/use-cases/fetch-divination-card-rewards.use-case.ts
@@ -1,0 +1,48 @@
+import InfraException from 'infra/exceptions/infra.exception';
+import PoeNinjaService, { PoeNinjaQueryParams } from 'infra/http/poe-ninja';
+import parseDivinationCardReward, {
+  DivinationCardData,
+  DivinationCardReward,
+} from 'shared/helpers/parse-divination-card-reward.helper';
+
+export interface FetchDivinationCardRewardsUseCaseInterfaces {
+  readonly service: PoeNinjaService;
+}
+
+export interface FetchDivinationCardRewardsUseCaseConstructor {
+  readonly interfaces: FetchDivinationCardRewardsUseCaseInterfaces;
+}
+
+export interface CardRewardResult {
+  readonly cardName: string;
+  readonly reward: DivinationCardReward;
+}
+
+export default class FetchDivinationCardRewardsUseCase {
+  private readonly service: PoeNinjaService;
+
+  constructor({ interfaces }: FetchDivinationCardRewardsUseCaseConstructor) {
+    this.service = interfaces.service;
+  }
+
+  async execute(league: string): Promise<CardRewardResult[]> {
+    const params: PoeNinjaQueryParams = { league, type: 'DivinationCard' };
+    const { lines } = await this.service.fetchItemOverview<{
+      lines: Array<DivinationCardData & { name: string }>;
+    }>(params);
+
+    if (!lines) {
+      throw new InfraException(
+        FetchDivinationCardRewardsUseCase.name,
+        'No data found',
+      );
+    }
+
+    return lines
+      .map((line) => {
+        const reward = parseDivinationCardReward(line);
+        return reward ? { cardName: line.name, reward } : null;
+      })
+      .filter((entry): entry is CardRewardResult => entry !== null);
+  }
+}

--- a/src/application/use-cases/tests/fetch-divination-card-rewards.use-case.spec.ts
+++ b/src/application/use-cases/tests/fetch-divination-card-rewards.use-case.spec.ts
@@ -1,0 +1,93 @@
+import FetchDivinationCardRewardsUseCase from 'application/use-cases/fetch-divination-card-rewards.use-case';
+import { DivinationCardRewardType } from 'shared/helpers/parse-divination-card-reward.helper';
+import type PoeNinjaService from 'infra/http/poe-ninja';
+
+describe(FetchDivinationCardRewardsUseCase.name, () => {
+  it('parses rewards from api', async () => {
+    const lines = [
+      {
+        name: 'The Doctor',
+        explicitModifiers: [{ text: '<uniqueitem>{Headhunter}' }],
+      },
+      {
+        name: 'The Wrath',
+        explicitModifiers: [{ text: '<currencyitem>{10x Chaos Orb}' }],
+      },
+      {
+        name: 'Imperial Legacy',
+        explicitModifiers: [{ text: '<whiteitem>{Six-Link Imperial Bow}' }],
+      },
+      {
+        name: 'Hidden Socket',
+        explicitModifiers: [{ text: '<whiteitem>{Six-Socket Staff}' }],
+      },
+      {
+        name: 'Invalid',
+        explicitModifiers: [{ text: 'Something else' }],
+      },
+    ];
+
+    const service = {
+      fetchItemOverview: jest.fn().mockResolvedValue({ lines }),
+    } as unknown as PoeNinjaService;
+
+    const useCase = new FetchDivinationCardRewardsUseCase({
+      interfaces: { service },
+    });
+    const result = await useCase.execute('Sanctum');
+
+    expect(service.fetchItemOverview).toHaveBeenCalledWith({
+      league: 'Sanctum',
+      type: 'DivinationCard',
+    });
+    expect(result).toEqual([
+      {
+        cardName: 'The Doctor',
+        reward: {
+          name: 'Headhunter',
+          type: DivinationCardRewardType.UniqueItem,
+          corrupted: false,
+        },
+      },
+      {
+        cardName: 'The Wrath',
+        reward: {
+          name: 'Chaos Orb',
+          type: DivinationCardRewardType.CurrencyItem,
+          corrupted: false,
+          amount: 10,
+        },
+      },
+      {
+        cardName: 'Imperial Legacy',
+        reward: {
+          name: 'Imperial Bow',
+          type: 'whiteitem',
+          corrupted: false,
+          links: 6,
+        },
+      },
+      {
+        cardName: 'Hidden Socket',
+        reward: {
+          name: 'Staff',
+          type: 'whiteitem',
+          corrupted: false,
+          sockets: 6,
+        },
+      },
+    ]);
+  });
+
+  it('throws when no lines returned', async () => {
+    const service = {
+      fetchItemOverview: jest.fn().mockResolvedValue({}),
+    } as unknown as PoeNinjaService;
+
+    const useCase = new FetchDivinationCardRewardsUseCase({
+      interfaces: { service },
+    });
+
+    await expect(useCase.execute('Sanctum')).rejects.toThrow('No data found');
+  });
+});

--- a/src/shared/helpers/parse-divination-card-reward.helper.ts
+++ b/src/shared/helpers/parse-divination-card-reward.helper.ts
@@ -1,0 +1,101 @@
+export interface DivinationCardData {
+  explicitModifiers?: { text: string }[];
+}
+
+export enum DivinationCardRewardType {
+  CurrencyItem = 'currencyitem',
+  UniqueItem = 'uniqueitem',
+  GemItem = 'gemitem',
+  DivinationCard = 'divination',
+}
+
+export interface DivinationCardReward {
+  name: string;
+  type: string;
+  corrupted: boolean;
+  amount?: number;
+  links?: number;
+  sockets?: number;
+  level?: number;
+}
+
+const TOKEN_PATTERN = /<([^>]+)>{([^{}]*?)}/g;
+const QUANTITY_PREFIX = /^(\d+)x\s+/i;
+const LEVEL_PATTERN = /Level\s+(\d+)\s*/i;
+const SUPPORT_SUFFIX = /\s+Support$/i;
+const LINK_PREFIX = /^(?:(?<word>\w+)-Linked?|(?<word2>\w+)-Link)\s+/i;
+const SOCKET_PREFIX = /^(?:(?<word>\w+)-Socket(?:ed)?|(?<word2>\w+)-Socketed?)\s+/i;
+const NUMBER_WORDS: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+};
+
+export default function parseDivinationCardReward(
+  card: DivinationCardData,
+): DivinationCardReward | null {
+  if (!card.explicitModifiers?.length) {
+    return null;
+  }
+
+  const text = card.explicitModifiers.map((m) => m.text).join('\n');
+
+  let reward: { name: string; type: string } | null = null;
+  let corrupted = false;
+  let amount: number | undefined;
+  let links: number | undefined;
+  let sockets: number | undefined;
+  let level: number | undefined;
+
+  for (const match of text.matchAll(TOKEN_PATTERN)) {
+    const tag = match[1].toLowerCase();
+    const content = match[2];
+
+    if (tag === 'corrupted') {
+      corrupted = true;
+      continue;
+    }
+
+    if (!reward && (/item$/.test(tag) || tag === 'divination')) {
+      let name = content;
+      const quantityMatch = name.match(QUANTITY_PREFIX);
+      if (quantityMatch) {
+        amount = parseInt(quantityMatch[1], 10);
+        name = name.replace(quantityMatch[0], '');
+      }
+      const levelMatch = name.match(LEVEL_PATTERN);
+      if (levelMatch) {
+        level = parseInt(levelMatch[1], 10);
+        name = name.replace(levelMatch[0], '');
+      }
+      name = name.trim();
+
+      const linkMatch = name.match(LINK_PREFIX);
+      if (linkMatch) {
+        const word = linkMatch.groups?.word || linkMatch.groups?.word2 || '';
+        const lower = word.toLowerCase();
+        links = NUMBER_WORDS[lower] ?? parseInt(word, 10);
+        name = name.slice(linkMatch[0].length);
+      }
+
+      const socketMatch = name.match(SOCKET_PREFIX);
+      if (socketMatch) {
+        const word = socketMatch.groups?.word || socketMatch.groups?.word2 || '';
+        const lower = word.toLowerCase();
+        sockets = NUMBER_WORDS[lower] ?? parseInt(word, 10);
+        name = name.slice(socketMatch[0].length);
+      }
+
+      if (tag === DivinationCardRewardType.GemItem && SUPPORT_SUFFIX.test(name)) {
+        name = name.replace(SUPPORT_SUFFIX, '');
+      }
+
+      reward = { name, type: tag };
+    }
+  }
+
+  return reward ? { ...reward, corrupted, amount, links, sockets, level } : null;
+}

--- a/src/shared/helpers/tests/parse-divination-card-reward.integration.spec.ts
+++ b/src/shared/helpers/tests/parse-divination-card-reward.integration.spec.ts
@@ -1,0 +1,70 @@
+import { execSync } from 'child_process';
+import PoeNinjaService from 'infra/http/poe-ninja';
+import type {
+  IHttpClient,
+  HttpClientGetProps,
+  HttpClientResponse,
+} from 'application/ports/http-client.interface';
+import StatusCode from 'status-code-enum';
+import cards from 'config/cards';
+import currencyCards from 'config/currency-cards';
+import parseDivinationCardReward, {
+  DivinationCardData,
+} from 'shared/helpers/parse-divination-card-reward.helper';
+
+class CurlHttpClient implements IHttpClient {
+  async get<T>(props: HttpClientGetProps): Promise<HttpClientResponse<T>> {
+    const json = execSync(`curl -sL "${props.url}"`).toString();
+    const data = JSON.parse(json) as T;
+    return { data, headers: {}, statusCode: StatusCode.SuccessOK };
+  }
+}
+
+describe('Parse divination card reward integration', () => {
+  let cardMap: Record<string, DivinationCardData>;
+
+  beforeAll(async () => {
+    const service = new PoeNinjaService(new CurlHttpClient());
+    const { lines } = await service.fetchItemOverview<{
+      lines: Array<DivinationCardData & { name: string }>;
+    }>({
+      league: 'Standard',
+      type: 'DivinationCard',
+    });
+
+    cardMap = Object.fromEntries(
+      lines.map((line) => [line.name, line]),
+    );
+  }, 20000);
+
+  [...cards, ...currencyCards].forEach((card) => {
+    const cardName = card.cardName;
+    const expected = card.rewardName;
+
+    it(`parses reward for ${cardName}`, () => {
+      const data = cardMap[cardName];
+      expect(data).toBeDefined();
+      const reward = parseDivinationCardReward(data);
+      expect(reward).not.toBeNull();
+
+      if (!reward) return;
+      if (expected.endsWith(' Support')) {
+        expect(reward.name).toBe(expected.replace(/ Support$/, ''));
+      } else {
+        expect(reward.name).toBe(expected);
+      }
+
+      if ('links' in card && card.links > 0 && reward.links !== undefined) {
+        expect(reward.links).toBe(card.links);
+      }
+
+      if ('gemLevel' in card && card.gemLevel > 0 && reward.level !== undefined) {
+        expect(reward.level).toBe(card.gemLevel);
+      }
+
+      if ('amount' in card && card.amount > 1 && reward.amount !== undefined) {
+        expect(reward.amount).toBe(card.amount);
+      }
+    });
+  });
+});

--- a/src/shared/helpers/tests/parse-divination-card-reward.spec.ts
+++ b/src/shared/helpers/tests/parse-divination-card-reward.spec.ts
@@ -1,0 +1,175 @@
+import parseDivinationCardReward, {
+  DivinationCardData,
+  DivinationCardRewardType,
+} from 'shared/helpers/parse-divination-card-reward.helper';
+
+describe(parseDivinationCardReward.name, () => {
+  it('extracts reward from The Doctor', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [{ text: '<uniqueitem>{Headhunter}' }],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Headhunter',
+      type: DivinationCardRewardType.UniqueItem,
+      corrupted: false,
+    });
+  });
+
+  it('extracts reward from currency card with quantity', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [{ text: '<currencyitem>{19x Mirror Shard}' }],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Mirror Shard',
+      type: DivinationCardRewardType.CurrencyItem,
+      corrupted: false,
+      amount: 19,
+    });
+  });
+
+  it('extracts reward from The Fiend', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [
+        { text: '<uniqueitem>{Headhunter}\n<corrupted>{Corrupted}' },
+      ],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Headhunter',
+      type: DivinationCardRewardType.UniqueItem,
+      corrupted: true,
+    });
+  });
+
+  it('extracts reward from The Demon', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [
+        {
+          text:
+            '<uniqueitem>{Headhunter}\n<corrupted>{Two-Implicit}\n<corrupted>{Corrupted}',
+        },
+      ],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Headhunter',
+      type: DivinationCardRewardType.UniqueItem,
+      corrupted: true,
+    });
+  });
+
+  it('extracts corrupted gem reward', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [
+        { text: '<gemitem>{Level 4 Empower}\n<corrupted>{Corrupted}' },
+      ],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Empower',
+      type: DivinationCardRewardType.GemItem,
+      corrupted: true,
+      level: 4,
+    });
+  });
+
+  it('extracts gem reward without corruption', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [{ text: '<gemitem>{Level 3 Enlighten}' }],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Enlighten',
+      type: DivinationCardRewardType.GemItem,
+      corrupted: false,
+      level: 3,
+    });
+  });
+
+  it('returns null when modifier is missing', () => {
+    expect(parseDivinationCardReward({})).toBeNull();
+  });
+
+  it('flags corruption for non-standard corrupted tags', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [
+        { text: '<uniqueitem>{Headhunter}\n<corrupted>{Six-Linked}' },
+      ],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Headhunter',
+      type: DivinationCardRewardType.UniqueItem,
+      corrupted: true,
+    });
+  });
+
+  it('extracts links from six-link rewards', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [{ text: '<whiteitem>{Six-Link Imperial Bow}' }],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Imperial Bow',
+      type: 'whiteitem',
+      corrupted: false,
+      links: 6,
+    });
+  });
+
+  it('extracts links from six-linked rewards', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [{ text: '<whiteitem>{Six-Linked Body Armour}' }],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Body Armour',
+      type: 'whiteitem',
+      corrupted: false,
+      links: 6,
+    });
+  });
+
+  it('extracts sockets from six-socket rewards', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [{ text: '<whiteitem>{Six-Socket Staff}' }],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Staff',
+      type: 'whiteitem',
+      corrupted: false,
+      sockets: 6,
+    });
+  });
+
+  it('extracts sockets from six-socketed rewards', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [{ text: '<whiteitem>{Six-Socketed Bow}' }],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Bow',
+      type: 'whiteitem',
+      corrupted: false,
+      sockets: 6,
+    });
+  });
+
+  it('parses levelled gem reward in the middle of the string', () => {
+    const card: DivinationCardData = {
+      explicitModifiers: [
+        { text: '<gemitem>{Awakened Level 5 Multistrike Support}' },
+      ],
+    };
+
+    expect(parseDivinationCardReward(card)).toEqual({
+      name: 'Awakened Multistrike',
+      type: DivinationCardRewardType.GemItem,
+      corrupted: false,
+      level: 5,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- handle missing explicit modifiers
- detect all <corrupted> tags
- strip level tokens that occur mid-string and remove Support suffix for gems
- parse link count for six-link rewards
- capture gem level from reward text
- **parse socket count**
- **parse reward quantity**
- test non-standard corrupted tags, levelled gem rewards, six-link rewards, socketed items, and multi-quantity currency rewards

## Testing
- `npm test --silent -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684b52925000833399689c5e1eb8a421